### PR TITLE
Skip download URL on 404

### DIFF
--- a/models.py
+++ b/models.py
@@ -124,8 +124,10 @@ class FantiaDownloader:
         self.perform_download(fanclub_icon_url, fanclub_icon_filename, server_filename=self.use_server_filenames)
 
         background_url = fanclub_json["fanclub"]["background"]
-        background_filename = os.path.join(fanclub_directory, "background" + self.process_content_type(background_url))
-        self.perform_download(background_url, background_filename, server_filename=self.use_server_filenames)
+
+        if background_url:
+            background_filename = os.path.join(fanclub_directory, "background" + self.process_content_type(background_url))
+            self.perform_download(background_url, background_filename, server_filename=self.use_server_filenames)
 
     def download_fanclub(self, fanclub, limit=0):
         """Download a fanclub."""

--- a/models.py
+++ b/models.py
@@ -118,16 +118,19 @@ class FantiaDownloader:
         header_url = fanclub_json["fanclub"]["cover"]["original"]
         if header_url:
             header_filename = os.path.join(fanclub_directory, "header" + self.process_content_type(header_url))
+            self.output("Downloading fanclub header...\n")
             self.perform_download(header_url, header_filename, server_filename=self.use_server_filenames)
 
         fanclub_icon_url = fanclub_json["fanclub"]["icon"]["original"]
         if fanclub_icon_url:
             fanclub_icon_filename = os.path.join(fanclub_directory, "icon" + self.process_content_type(fanclub_icon_url))
+            self.output("Downloading fanclub icon...\n")
             self.perform_download(fanclub_icon_url, fanclub_icon_filename, server_filename=self.use_server_filenames)
 
         background_url = fanclub_json["fanclub"]["background"]
         if background_url:
             background_filename = os.path.join(fanclub_directory, "background" + self.process_content_type(background_url))
+            self.output("Downloading fanclub background...\n")
             self.perform_download(background_url, background_filename, server_filename=self.use_server_filenames)
 
     def download_fanclub(self, fanclub, limit=0):
@@ -190,6 +193,7 @@ class FantiaDownloader:
         request = self.session.get(url, stream=True)
 
         if request.status_code == 404:
+            self.output("Download URL returned 404. Skipping...\n")
             return
 
         request.raise_for_status()

--- a/models.py
+++ b/models.py
@@ -116,15 +116,16 @@ class FantiaDownloader:
         self.save_metadata(fanclub_json, fanclub_directory)
 
         header_url = fanclub_json["fanclub"]["cover"]["original"]
-        header_filename = os.path.join(fanclub_directory, "header" + self.process_content_type(header_url))
-        self.perform_download(header_url, header_filename, server_filename=self.use_server_filenames)
+        if header_url:
+            header_filename = os.path.join(fanclub_directory, "header" + self.process_content_type(header_url))
+            self.perform_download(header_url, header_filename, server_filename=self.use_server_filenames)
 
         fanclub_icon_url = fanclub_json["fanclub"]["icon"]["original"]
-        fanclub_icon_filename = os.path.join(fanclub_directory, "icon" + self.process_content_type(fanclub_icon_url))
-        self.perform_download(fanclub_icon_url, fanclub_icon_filename, server_filename=self.use_server_filenames)
+        if fanclub_icon_url:
+            fanclub_icon_filename = os.path.join(fanclub_directory, "icon" + self.process_content_type(fanclub_icon_url))
+            self.perform_download(fanclub_icon_url, fanclub_icon_filename, server_filename=self.use_server_filenames)
 
         background_url = fanclub_json["fanclub"]["background"]
-
         if background_url:
             background_filename = os.path.join(fanclub_directory, "background" + self.process_content_type(background_url))
             self.perform_download(background_url, background_filename, server_filename=self.use_server_filenames)

--- a/models.py
+++ b/models.py
@@ -188,6 +188,10 @@ class FantiaDownloader:
     def perform_download(self, url, filename, server_filename=False):
         """Perform a download for the specified URL while showing progress."""
         request = self.session.get(url, stream=True)
+
+        if request.status_code == 404:
+            return
+
         request.raise_for_status()
 
         if server_filename:


### PR DESCRIPTION
When Fantia contents are 404, an exception will be invoke and the download will be stop.