### PR TITLE
Exclude files by file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ download options:
                         download posts from all fanclubs backed on a paid plan
   -d %Y-%m, --download-month %Y-%m
                         download posts only from a specific month, e.g. 2007-08
-  -e EXCLUDED_FILE, --exclude EXCLUDED_FILE
-                        file containing a list of file names to exclude from downloading
+  --exclude EXCLUDE_FILE
+                        file containing a list of filenames to exclude from downloading
 ```
 
 When parsing for external links using `-x`, a .crawljob file is created in your root directory (either the directory provided with `-o` or the directory the script is being run from) that can be parsed by [JDownloader](http://jdownloader.org/). As posts are parsed, links will be appended and assigned their appropriate post directories for download. You can import this file manually into JDownloader (File -> Load Linkcontainer) or setup the Folder Watch plugin to watch your root directory for .crawljob files.

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ download options:
                         download posts from all fanclubs backed on a paid plan
   -d %Y-%m, --download-month %Y-%m
                         download posts only from a specific month, e.g. 2007-08
+  -x EXCLUDED_FILE, --exclude EXCLUDED_FILE
+                        file containing a list of file names to exclude from downloading
 ```
 
 When parsing for external links using `-x`, a .crawljob file is created in your root directory (either the directory provided with `-o` or the directory the script is being run from) that can be parsed by [JDownloader](http://jdownloader.org/). As posts are parsed, links will be appended and assigned their appropriate post directories for download. You can import this file manually into JDownloader (File -> Load Linkcontainer) or setup the Folder Watch plugin to watch your root directory for .crawljob files.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ download options:
                         download posts from all fanclubs backed on a paid plan
   -d %Y-%m, --download-month %Y-%m
                         download posts only from a specific month, e.g. 2007-08
-  -x EXCLUDED_FILE, --exclude EXCLUDED_FILE
+  -e EXCLUDED_FILE, --exclude EXCLUDED_FILE
                         file containing a list of file names to exclude from downloading
 ```
 

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     dl_group.add_argument("-f", "--download-fanclubs", action="store_true", dest="download_fanclubs", help="download posts from all followed fanclubs")
     dl_group.add_argument("-p", "--download-paid-fanclubs", action="store_true", dest="download_paid_fanclubs", help="download posts from all fanclubs backed on a paid plan")
     dl_group.add_argument("-d", "--download-month", dest="month_limit", metavar="%Y-%m", help="download posts only from a specific month, e.g. 2007-08")
-    dl_group.add_argument("--exclude", dest="exclude_file", metavar="EXCLUDE_FILE", help="file containing a list of server-defined filenames to exclude from downloading")
+    dl_group.add_argument("--exclude", dest="exclude_file", metavar="EXCLUDE_FILE", help="file containing a list of filenames to exclude from downloading")
 
 
     cmdl_opts = cmdl_parser.parse_args()

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -42,8 +42,8 @@ if __name__ == "__main__":
     dl_group.add_argument("-t", "--download-thumbnail", action="store_true", dest="download_thumb", help="download post thumbnails")
     dl_group.add_argument("-f", "--download-fanclubs", action="store_true", dest="download_fanclubs", help="download posts from all followed fanclubs")
     dl_group.add_argument("-p", "--download-paid-fanclubs", action="store_true", dest="download_paid_fanclubs", help="download posts from all fanclubs backed on a paid plan")
-    dl_group.add_argument("-d", "--download-month", dest="month_limit", metavar='%Y-%m', help="download posts only from a specific month, e.g. 2007-08")
-    dl_group.add_argument("-e", "--exclude", dest="excluded_file", help="file containing a list of file names to exclude from downloading")
+    dl_group.add_argument("-d", "--download-month", dest="month_limit", metavar="%Y-%m", help="download posts only from a specific month, e.g. 2007-08")
+    dl_group.add_argument("--exclude", dest="exclude_file", metavar="EXCLUDE_FILE", help="file containing a list of server-defined filenames to exclude from downloading")
 
 
     cmdl_opts = cmdl_parser.parse_args()
@@ -51,7 +51,6 @@ if __name__ == "__main__":
     session_arg = cmdl_opts.session_arg
     email = cmdl_opts.email
     password = cmdl_opts.password
-    excluded = cmdl_opts.excluded_file
 
     if (email or password or cmdl_opts.netrc) and not session_arg:
         sys.exit("Logging in from the command line is no longer supported. Please provide a session cookie using -c/--cookie. See the README for more information.")
@@ -75,14 +74,8 @@ if __name__ == "__main__":
     #     if not password:
     #         password = getpass.getpass("Password: ")
 
-	# Read files to exclude
-    excluded_files = []
-    if excluded:
-        with open(excluded, "r") as f:
-            excluded_files = [line.rstrip("\n") for line in f]
-
     try:
-        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, excluded=excluded_files)
+        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, exclude_file=cmdl_opts.exclude_file)
         if cmdl_opts.download_fanclubs:
             try:
                 downloader.download_followed_fanclubs(limit=cmdl_opts.limit)

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     dl_group.add_argument("-f", "--download-fanclubs", action="store_true", dest="download_fanclubs", help="download posts from all followed fanclubs")
     dl_group.add_argument("-p", "--download-paid-fanclubs", action="store_true", dest="download_paid_fanclubs", help="download posts from all fanclubs backed on a paid plan")
     dl_group.add_argument("-d", "--download-month", dest="month_limit", metavar='%Y-%m', help="download posts only from a specific month, e.g. 2007-08")
-    dl_group.add_argument("-x", "--exclude", dest="excluded_file", help="file containing a list of file names to exclude from downloading")
+    dl_group.add_argument("-e", "--exclude", dest="excluded_file", help="file containing a list of file names to exclude from downloading")
 
 
     cmdl_opts = cmdl_parser.parse_args()

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -43,6 +43,7 @@ if __name__ == "__main__":
     dl_group.add_argument("-f", "--download-fanclubs", action="store_true", dest="download_fanclubs", help="download posts from all followed fanclubs")
     dl_group.add_argument("-p", "--download-paid-fanclubs", action="store_true", dest="download_paid_fanclubs", help="download posts from all fanclubs backed on a paid plan")
     dl_group.add_argument("-d", "--download-month", dest="month_limit", metavar='%Y-%m', help="download posts only from a specific month, e.g. 2007-08")
+    dl_group.add_argument("-x", "--exclude", dest="excluded_file", help="file containing a list of file names to exclude from downloading")
 
 
     cmdl_opts = cmdl_parser.parse_args()
@@ -50,6 +51,7 @@ if __name__ == "__main__":
     session_arg = cmdl_opts.session_arg
     email = cmdl_opts.email
     password = cmdl_opts.password
+    excluded = cmdl_opts.excluded_file
 
     if (email or password or cmdl_opts.netrc) and not session_arg:
         sys.exit("Logging in from the command line is no longer supported. Please provide a session cookie using -c/--cookie. See the README for more information.")
@@ -73,8 +75,14 @@ if __name__ == "__main__":
     #     if not password:
     #         password = getpass.getpass("Password: ")
 
+	# Read files to exclude
+    excluded_files = []
+    if excluded:
+        with open(excluded, "r") as f:
+            excluded_files = [line.rstrip("\n") for line in f]
+
     try:
-        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit)
+        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, excluded=excluded_files)
         if cmdl_opts.download_fanclubs:
             try:
                 downloader.download_followed_fanclubs(limit=cmdl_opts.limit)

--- a/models.py
+++ b/models.py
@@ -70,7 +70,7 @@ class FantiaDownloader:
         self.use_server_filenames = use_server_filenames
         self.mark_incomplete_posts = mark_incomplete_posts
         self.month_limit = dt.strptime(month_limit, "%Y-%m") if month_limit else None
-        self.excluded_files = excluded
+        self.excluded_files = excluded if excluded is not None else []
         self.session = requests.session()
         self.login()
 

--- a/models.py
+++ b/models.py
@@ -56,7 +56,7 @@ class FantiaClub:
 
 
 class FantiaDownloader:
-    def __init__(self, session_arg, chunk_size=1024 * 1024 * 5, dump_metadata=False, parse_for_external_links=False, download_thumb=False, directory=None, quiet=True, continue_on_error=False, use_server_filenames=False, mark_incomplete_posts=False, month_limit=None):
+    def __init__(self, session_arg, chunk_size=1024 * 1024 * 5, dump_metadata=False, parse_for_external_links=False, download_thumb=False, directory=None, quiet=True, continue_on_error=False, use_server_filenames=False, mark_incomplete_posts=False, month_limit=None, excluded=None):
         # self.email = email
         # self.password = password
         self.session_arg = session_arg
@@ -70,15 +70,9 @@ class FantiaDownloader:
         self.use_server_filenames = use_server_filenames
         self.mark_incomplete_posts = mark_incomplete_posts
         self.month_limit = dt.strptime(month_limit, "%Y-%m") if month_limit else None
-        self.ignored_files = self.load_ignored_files()
+        self.excluded_files = excluded
         self.session = requests.session()
         self.login()
-
-    def load_ignored_files(self) -> list:
-        """Loads a list of files to ignore when downloading"""
-        with open("ignored.txt", "r") as f:
-            data = [line.rstrip("\n") for line in f]
-        return data
 
     def output(self, output):
         """Write output to the console."""
@@ -273,11 +267,10 @@ class FantiaDownloader:
         if server_filename:
             filename = os.path.join(os.path.dirname(filename), os.path.basename(url_path))
 
-        # Check if should ignore
-        print(url_path.rpartition("/")[2])
-        if url_path.rpartition("/")[2] in self.ignored_files:
-            self.output("Ignored file found (skipping): {}\n".format(filename))
-            return 
+        # Check if should exclude from saving
+        if url_path.rpartition("/")[2] in self.excluded_files:
+            self.output("Excluded file found (skipping): {}\n".format(filename))
+            return
 
         file_size = int(request.headers["Content-Length"])
         if os.path.isfile(filename) and os.stat(filename).st_size == file_size:

--- a/models.py
+++ b/models.py
@@ -56,7 +56,7 @@ class FantiaClub:
 
 
 class FantiaDownloader:
-    def __init__(self, session_arg, chunk_size=1024 * 1024 * 5, dump_metadata=False, parse_for_external_links=False, download_thumb=False, directory=None, quiet=True, continue_on_error=False, use_server_filenames=False, mark_incomplete_posts=False, month_limit=None, excluded=None):
+    def __init__(self, session_arg, chunk_size=1024 * 1024 * 5, dump_metadata=False, parse_for_external_links=False, download_thumb=False, directory=None, quiet=True, continue_on_error=False, use_server_filenames=False, mark_incomplete_posts=False, month_limit=None, exclude_file=None):
         # self.email = email
         # self.password = password
         self.session_arg = session_arg
@@ -70,9 +70,11 @@ class FantiaDownloader:
         self.use_server_filenames = use_server_filenames
         self.mark_incomplete_posts = mark_incomplete_posts
         self.month_limit = dt.strptime(month_limit, "%Y-%m") if month_limit else None
-        self.excluded_files = excluded if excluded is not None else []
+        self.exclude_file = exclude_file
+        self.exclusions = []
         self.session = requests.session()
         self.login()
+        self.create_exclusions()
 
     def output(self, output):
         """Write output to the console."""
@@ -126,6 +128,12 @@ class FantiaDownloader:
         # if not (check_user.ok or check_user.status_code == 304):
         #     sys.exit("Error: Invalid session")
 
+    def create_exclusions(self):
+        """Read files to exclude from downloading."""
+        if self.exclude_file:
+            with open(self.exclude_file, "r") as file:
+                self.exclusions = [line.rstrip("\n") for line in file]
+
     def process_content_type(self, url):
         """Process the Content-Type from a request header and use it to build a filename."""
         url_header = self.session.head(url)
@@ -149,19 +157,19 @@ class FantiaDownloader:
         if header_url:
             header_filename = os.path.join(fanclub_directory, "header" + self.process_content_type(header_url))
             self.output("Downloading fanclub header...\n")
-            self.perform_download(header_url, header_filename, server_filename=self.use_server_filenames)
+            self.perform_download(header_url, header_filename, use_server_filename=self.use_server_filenames)
 
         fanclub_icon_url = fanclub_json["fanclub"]["icon"]["original"]
         if fanclub_icon_url:
             fanclub_icon_filename = os.path.join(fanclub_directory, "icon" + self.process_content_type(fanclub_icon_url))
             self.output("Downloading fanclub icon...\n")
-            self.perform_download(fanclub_icon_url, fanclub_icon_filename, server_filename=self.use_server_filenames)
+            self.perform_download(fanclub_icon_url, fanclub_icon_filename, use_server_filename=self.use_server_filenames)
 
         background_url = fanclub_json["fanclub"]["background"]
         if background_url:
             background_filename = os.path.join(fanclub_directory, "background" + self.process_content_type(background_url))
             self.output("Downloading fanclub background...\n")
-            self.perform_download(background_url, background_filename, server_filename=self.use_server_filenames)
+            self.perform_download(background_url, background_filename, use_server_filename=self.use_server_filenames)
 
     def download_fanclub(self, fanclub, limit=0):
         """Download a fanclub."""
@@ -253,7 +261,7 @@ class FantiaDownloader:
             else:
                 page_number += 1
 
-    def perform_download(self, url, filename, server_filename=False):
+    def perform_download(self, url, filepath, use_server_filename=False):
         """Perform a download for the specified URL while showing progress."""
         request = self.session.get(url, stream=True)
 
@@ -264,21 +272,26 @@ class FantiaDownloader:
         request.raise_for_status()
 
         url_path = unquote(request.url.split("?", 1)[0])
-        if server_filename:
-            filename = os.path.join(os.path.dirname(filename), os.path.basename(url_path))
+        server_filename = os.path.basename(url_path)
+        filename = os.path.basename(filepath)
+        if use_server_filename:
+            filepath = os.path.join(os.path.dirname(filepath), server_filename)
 
-        # Check if should exclude from saving
-        if url_path.rpartition("/")[2] in self.excluded_files:
-            self.output("Excluded file found (skipping): {}\n".format(filename))
+        # Check if filename is in exclusion list
+        if server_filename in self.exclusions:
+            self.output("Server filename in exclusion list (skipping): {}\n".format(server_filename))
+            return
+        elif filename in self.exclusions:
+            self.output("Filename in exclusion list (skipping): {}\n".format(filename))
             return
 
         file_size = int(request.headers["Content-Length"])
-        if os.path.isfile(filename) and os.stat(filename).st_size == file_size:
-            self.output("File found (skipping): {}\n".format(filename))
+        if os.path.isfile(filepath) and os.stat(filepath).st_size == file_size:
+            self.output("File found (skipping): {}\n".format(filepath))
             return
 
-        self.output("File: {}\n".format(filename))
-        base_filename, original_extension = os.path.splitext(filename)
+        self.output("File: {}\n".format(filepath))
+        base_filename, original_extension = os.path.splitext(filepath)
         incomplete_filename = base_filename + ".incomplete"
 
         downloaded = 0
@@ -290,23 +303,23 @@ class FantiaDownloader:
                 percent = int(100 * downloaded / file_size)
                 self.output("\r|{0}{1}| {2}% ".format("\u2588" * done, " " * (25 - done), percent))
         self.output("\n")
-        os.rename(incomplete_filename, filename)
+        os.rename(incomplete_filename, filepath)
 
         modification_time_string = request.headers["Last-Modified"]
         modification_time = int(dt.strptime(modification_time_string, "%a, %d %b %Y %H:%M:%S %Z").timestamp())
         if modification_time:
             access_time = int(time.time())
-            os.utime(filename, times=(access_time, modification_time))
+            os.utime(filepath, times=(access_time, modification_time))
 
     def download_photo(self, photo_url, photo_counter, gallery_directory):
         """Download a photo to the post's directory."""
         extension = self.process_content_type(photo_url)
         filename = os.path.join(gallery_directory, str(photo_counter) + extension) if gallery_directory else str()
-        self.perform_download(photo_url, filename, server_filename=self.use_server_filenames)
+        self.perform_download(photo_url, filename, use_server_filename=self.use_server_filenames)
 
     def download_file(self, download_url, filename, post_directory):
         """Download a file to the post's directory."""
-        self.perform_download(download_url, filename, server_filename=True) # Force serve filenames to prevent duplicate collision
+        self.perform_download(download_url, filename, use_server_filename=True) # Force serve filenames to prevent duplicate collision
 
     def download_post_content(self, post_json, post_directory):
         """Parse the post's content to determine whether to save the content as a photo gallery or file."""
@@ -360,7 +373,7 @@ class FantiaDownloader:
         """Download a thumbnail to the post's directory."""
         extension = self.process_content_type(thumb_url)
         filename = os.path.join(post_directory, "thumb" + extension)
-        self.perform_download(thumb_url, filename, server_filename=self.use_server_filenames)
+        self.perform_download(thumb_url, filename, use_server_filename=self.use_server_filenames)
 
     def download_post(self, post_id):
         """Download a post to its own directory."""


### PR DESCRIPTION
Adds a flag for skipping downloads of files that match a list of filenames.

Flag + Help text: 
```
-e EXCLUDED_FILE, --exclude EXCLUDED_FILE
                        file containing a list of file names to exclude from downloading
```

Example usage:
```
fantiadl.py -c cookie -e ignored.txt <url>
```