### PR TITLE
Handle duplicate post titles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,7 @@ ENV/
 *.gif
 *.mp4
 *.webm
+*.zip
 *.incomplete
 
 # Metadata


### PR DESCRIPTION
Fixes #58. Duplicate post titles are checked at the start of each post. If a duplicate title is found, a counter is appended amd incremented until there's no collision.