### PR TITLE
Address issue with blog images (#69)

### DIFF
--- a/models.py
+++ b/models.py
@@ -136,8 +136,8 @@ class FantiaDownloader:
 
     def process_content_type(self, url):
         """Process the Content-Type from a request header and use it to build a filename."""
-        url_header = self.session.head(url)
-        mimetype = url_header.headers["Content-Type"]
+        r = self.session.get(url)
+        mimetype = r.headers['content-type']
         extension = guess_extension(mimetype, url)
         return extension
 
@@ -373,7 +373,7 @@ class FantiaDownloader:
                 os.makedirs(gallery_directory, exist_ok=True)
                 for op in blog_json["ops"]:
                     if type(op["insert"]) is dict and op["insert"].get("fantiaImage"):
-                        photo_url = op["insert"]["fantiaImage"]["url"]
+                        photo_url = "https://fantia.jp/" + op["insert"]["fantiaImage"]["original_url"]
                         self.download_photo(photo_url, photo_counter, gallery_directory)
                         photo_counter += 1
             else:

--- a/models.py
+++ b/models.py
@@ -136,8 +136,8 @@ class FantiaDownloader:
 
     def process_content_type(self, url):
         """Process the Content-Type from a request header and use it to build a filename."""
-        r = self.session.get(url)
-        mimetype = r.headers['content-type']
+        url_header = self.session.head(url, allow_redirects=True)
+        mimetype = url_header.headers["Content-Type"]
         extension = guess_extension(mimetype, url)
         return extension
 

--- a/models.py
+++ b/models.py
@@ -373,7 +373,7 @@ class FantiaDownloader:
                 os.makedirs(gallery_directory, exist_ok=True)
                 for op in blog_json["ops"]:
                     if type(op["insert"]) is dict and op["insert"].get("fantiaImage"):
-                        photo_url = "https://fantia.jp/" + op["insert"]["fantiaImage"]["original_url"]
+                        photo_url = urljoin(BASE_URL, op["insert"]["fantiaImage"]["original_url"])
                         self.download_photo(photo_url, photo_counter, gallery_directory)
                         photo_counter += 1
             else:


### PR DESCRIPTION
The correct URL (or at least a redirect to it) for full-size blog post images is actually under "original_url" rather than "url" in the json.  Unfortunately, the prior version of process_content_type won't work on it since it doesn't actually link directly to the image (it won't detect the mimetype, and thus won't assign an extension).  I modified process_content_type slightly so it should now work as intended in all cases.