### PR TITLE
added .complete file for downloaded posts

### DIFF
--- a/fantiadl.py
+++ b/fantiadl.py
@@ -44,6 +44,7 @@ if __name__ == "__main__":
     dl_group.add_argument("-p", "--download-paid-fanclubs", action="store_true", dest="download_paid_fanclubs", help="download posts from all fanclubs backed on a paid plan")
     dl_group.add_argument("-d", "--download-month", dest="month_limit", metavar="%Y-%m", help="download posts only from a specific month, e.g. 2007-08")
     dl_group.add_argument("--exclude", dest="exclude_file", metavar="EXCLUDE_FILE", help="file containing a list of filenames to exclude from downloading")
+    dl_group.add_argument("--mark-complete", action="store_true", dest="mark_complete", help="mark completely downloaded posts and skip them the next run")
 
 
     cmdl_opts = cmdl_parser.parse_args()
@@ -75,7 +76,7 @@ if __name__ == "__main__":
     #         password = getpass.getpass("Password: ")
 
     try:
-        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, exclude_file=cmdl_opts.exclude_file)
+        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, exclude_file=cmdl_opts.exclude_file, mark_complete=cmdl_opts.mark_complete)
         if cmdl_opts.download_fanclubs:
             try:
                 downloader.download_followed_fanclubs(limit=cmdl_opts.limit)


### PR DESCRIPTION
My issue: when i rerun the downloader with parameters that would try to download already finished posts it takes quite a while to go through all files in the post just to get the "file already exists.. skipping" message.

so my idea was to check if all files that should have been downloaded are present and add an .complete file that will be checked after before actually downloading any files. 

so already downloaded posts should be skipped way faster.

caveat: posts that get edited later wont get downloaded.
i realize that i should parse the metadata for files that should be present instead of hijacking the download function.

i'll submit this pull request anyway for shits and giggles.