### PR TITLE
Check if file exists to prevent FileExistsError on rename

### DIFF
--- a/models.py
+++ b/models.py
@@ -331,7 +331,7 @@ class FantiaDownloader:
                 percent = int(100 * downloaded / file_size)
                 self.output("\r|{0}{1}| {2}% ".format("\u2588" * done, " " * (25 - done), percent))
         self.output("\n")
-        os.rename(incomplete_filename, filepath)
+        os.replace(incomplete_filename, filepath)
 
         modification_time_string = request.headers["Last-Modified"]
         modification_time = int(dt.strptime(modification_time_string, "%a, %d %b %Y %H:%M:%S %Z").timestamp())

--- a/models.py
+++ b/models.py
@@ -331,7 +331,9 @@ class FantiaDownloader:
                 percent = int(100 * downloaded / file_size)
                 self.output("\r|{0}{1}| {2}% ".format("\u2588" * done, " " * (25 - done), percent))
         self.output("\n")
-        os.replace(incomplete_filename, filepath)
+        if os.path.exists(filepath)
+            os.remove(filepath)
+        os.rename(incomplete_filename, filepath)
 
         modification_time_string = request.headers["Last-Modified"]
         modification_time = int(dt.strptime(modification_time_string, "%a, %d %b %Y %H:%M:%S %Z").timestamp())


### PR DESCRIPTION
If the same filename with a different filesize exists in the target directory (usually happens when a post was updated, or an old version of fantiadl was used to download the posts before), os.rename errors out and stops with a FileExistsError.

Using os.replace however would require Python 3.3+ I believe.