### PR TITLE
RFC: Database to store download state & metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,6 @@ ENV/
 
 # Jetbrains
 .idea/
+
+# Database
+*.db

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ options:
   -q, --quiet           suppress output
   -v, --version         show program's version number and exit
   --db DB_PATH          database to track post download state
+  --db-bypass-post-check
+                        bypass the metadata fetch if post is marked as complete in the database
 
 download options:
   -i, --ignore-errors   continue on download errors

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ options:
                         _session_id cookie or cookies.txt
   -q, --quiet           suppress output
   -v, --version         show program's version number and exit
+  --db DB_PATH          database to track post download state
 
 download options:
   -i, --ignore-errors   continue on download errors
@@ -39,6 +40,8 @@ download options:
   --exclude EXCLUDE_FILE
                         file containing a list of filenames to exclude from downloading
 ```
+
+To track post downloads, specify a database path using `--db`, e.g. `--db ~/fantiadl.db`. When existing post content downloads are encountered, they will be skipped over. When all post contents under a parent post have been downloaded, the post will be marked complete on the database and skipped over entirely on future encounters.
 
 When parsing for external links using `-x`, a .crawljob file is created in your root directory (either the directory provided with `-o` or the directory the script is being run from) that can be parsed by [JDownloader](http://jdownloader.org/). As posts are parsed, links will be appended and assigned their appropriate post directories for download. You can import this file manually into JDownloader (File -> Load Linkcontainer) or setup the Folder Watch plugin to watch your root directory for .crawljob files.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ options:
                         _session_id cookie or cookies.txt
   -q, --quiet           suppress output
   -v, --version         show program's version number and exit
-  --db DB_PATH          database to track post download state
+  --db DB_PATH          database to track post download state (creates tables when first specified)"
   --db-bypass-post-check
                         bypass checking a post for new content if it's marked as completed on the database
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ options:
   -v, --version         show program's version number and exit
   --db DB_PATH          database to track post download state
   --db-bypass-post-check
-                        bypass the metadata fetch if post is marked as complete in the database
+                        bypass checking a post for new content if it's marked as completed on the database
 
 download options:
   -i, --ignore-errors   continue on download errors
@@ -43,7 +43,7 @@ download options:
                         file containing a list of filenames to exclude from downloading
 ```
 
-To track post downloads, specify a database path using `--db`, e.g. `--db ~/fantiadl.db`. When existing post content downloads are encountered, they will be skipped over. When all post contents under a parent post have been downloaded, the post will be marked complete on the database and skipped over entirely on future encounters.
+To track post downloads, specify a database path using `--db`, e.g. `--db ~/fantiadl.db`. When existing post content downloads are encountered, they will be skipped over. When all post contents under a parent post have been downloaded, the post will be marked complete on the database. If future requests to download a post indicate the post was modified based on its timestamp, new contents will be checked for; this behavior can be disabled by setting `--db-bypass-post-check`.
 
 When parsing for external links using `-x`, a .crawljob file is created in your root directory (either the directory provided with `-o` or the directory the script is being run from) that can be parsed by [JDownloader](http://jdownloader.org/). As posts are parsed, links will be appended and assigned their appropriate post directories for download. You can import this file manually into JDownloader (File -> Load Linkcontainer) or setup the Folder Watch plugin to watch your root directory for .crawljob files.
 

--- a/db.py
+++ b/db.py
@@ -59,5 +59,5 @@ class FantiaDlDatabase:
 
     # UPDATE
 
-    def update_post_download_complete(self, id, download_complete):
+    def update_post_download_complete(self, id, download_complete=1):
         self.execute("UPDATE posts SET download_complete = ?, timestamp = ? WHERE id = ?", (download_complete, int(time.time()), id))

--- a/db.py
+++ b/db.py
@@ -61,3 +61,6 @@ class FantiaDlDatabase:
 
     def update_post_download_complete(self, id, download_complete=1):
         self.execute("UPDATE posts SET download_complete = ?, timestamp = ? WHERE id = ?", (download_complete, int(time.time()), id))
+
+    def update_post_converted_at(self, id, converted_at):
+        self.execute("UPDATE posts SET converted_at = ?, timestamp = ? WHERE id = ?", (converted_at, int(time.time()), id))

--- a/db.py
+++ b/db.py
@@ -10,6 +10,8 @@ class FantiaDatabase:
         self.conn.row_factory = sqlite3.Row
         self.cursor = self.conn.cursor()
 
+        self.cursor.execute("CREATE TABLE IF NOT EXISTS urls (url TEXT PRIMARY KEY, timestamp INTEGER)")
+
         self.conn.commit()
 
     def __del__(self):
@@ -29,3 +31,13 @@ class FantiaDatabase:
             return None
         self.cursor.execute(query, args)
         return self.cursor.fetchone()
+
+    # insert methods
+
+    def insert_url(self, url):
+        self.execute("INSERT INTO urls VALUES (?, ?)", (url, int(time.time())))
+
+    # select methods
+
+    def is_url_downloaded(self, url):
+        return self.fetchone("SELECT timestamp FROM urls WHERE url = ?", (url,)) is not None

--- a/db.py
+++ b/db.py
@@ -1,0 +1,31 @@
+import sqlite3
+
+class FantiaDatabase:
+    def __init__(self, db_path):
+        if db_path is None:
+            self.conn = None
+            return
+
+        self.conn = sqlite3.connect(db_path)
+        self.conn.row_factory = sqlite3.Row
+        self.cursor = self.conn.cursor()
+
+        self.conn.commit()
+
+    def __del__(self):
+        if self.conn is not None:
+            self.conn.close()
+
+    # assistant methods to compatibilize with no database mode
+
+    def execute(self, query, args):
+        if self.conn is None:
+            return
+        self.cursor.execute(query, args)
+        self.conn.commit()
+
+    def fetchone(self, query, args):
+        if self.conn is None:
+            return None
+        self.cursor.execute(query, args)
+        return self.cursor.fetchone()

--- a/db.py
+++ b/db.py
@@ -1,7 +1,7 @@
 import time
 import sqlite3
 
-class FantiaDatabase:
+class FantiaDlDatabase:
     def __init__(self, db_path):
         if db_path is None:
             self.conn = None
@@ -12,7 +12,6 @@ class FantiaDatabase:
         self.cursor = self.conn.cursor()
 
         self.cursor.execute("CREATE TABLE IF NOT EXISTS urls (url TEXT PRIMARY KEY, timestamp INTEGER)")
-
         self.cursor.execute("CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY, title TEXT, fanclub INTEGER, posted_at INTEGER, converted_at INTEGER, download_complete INTEGER, timestamp INTEGER)")
         self.cursor.execute("CREATE TABLE IF NOT EXISTS post_contents (id INTEGER PRIMARY KEY, parent_post INTEGER, title TEXT, category TEXT, price INTEGER, currency TEXT, timestamp INTEGER, FOREIGN KEY(parent_post) REFERENCES posts(id))")
 
@@ -22,7 +21,7 @@ class FantiaDatabase:
         if self.conn is not None:
             self.conn.close()
 
-    # assistant methods to compatibilize with no database mode
+    # Helper methods
 
     def execute(self, query, args):
         if self.conn is None:
@@ -36,7 +35,7 @@ class FantiaDatabase:
         self.cursor.execute(query, args)
         return self.cursor.fetchone()
 
-    # insert methods
+    # INSERT, REPLACE
 
     def insert_post(self, id, title, fanclub, posted_at, converted_at):
         self.execute("REPLACE INTO posts VALUES (?, ?, ?, ?, ?, 0, ?)", (id, title, fanclub, posted_at, converted_at, int(time.time())))
@@ -47,7 +46,7 @@ class FantiaDatabase:
     def insert_url(self, url):
         self.execute("INSERT INTO urls VALUES (?, ?)", (url, int(time.time())))
 
-    # select methods
+    # SELECT
 
     def find_post(self, id):
         return self.fetchone("SELECT * FROM posts WHERE id = ?", (id,))
@@ -58,7 +57,7 @@ class FantiaDatabase:
     def is_url_downloaded(self, url):
         return self.fetchone("SELECT timestamp FROM urls WHERE url = ?", (url,)) is not None
 
-    # update methods
+    # UPDATE
 
     def update_post_download_complete(self, id, download_complete):
         self.execute("UPDATE posts SET download_complete = ?, timestamp = ? WHERE id = ?", (download_complete, int(time.time()), id))

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -30,6 +30,7 @@ if __name__ == "__main__":
     cmdl_parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="suppress output")
     cmdl_parser.add_argument("-v", "--version", action="version", version=cmdl_version)
     cmdl_parser.add_argument("--db", dest="db_path", help="database to track post download state")
+    cmdl_parser.add_argument("--db-bypass-post-check", action="store_true", dest="db_bypass_post_check", help="bypass the metadata fetch if post is marked as complete in the database")
     cmdl_parser.add_argument("url", action="store", nargs="*", help="fanclub or post URL")
 
     dl_group = cmdl_parser.add_argument_group("download options")
@@ -77,7 +78,7 @@ if __name__ == "__main__":
     #         password = getpass.getpass("Password: ")
 
     try:
-        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, exclude_file=cmdl_opts.exclude_file, db_path=cmdl_opts.db_path)
+        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, exclude_file=cmdl_opts.exclude_file, db_path=cmdl_opts.db_path, db_bypass_post_check=cmdl_opts.db_bypass_post_check)
         if cmdl_opts.download_fanclubs:
             try:
                 downloader.download_followed_fanclubs(limit=cmdl_opts.limit)

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
     cmdl_parser.add_argument("-n", "--netrc", action="store_true", dest="netrc", help=argparse.SUPPRESS)
     cmdl_parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="suppress output")
     cmdl_parser.add_argument("-v", "--version", action="version", version=cmdl_version)
+    cmdl_parser.add_argument("--db", dest="db_path", help="sqlite3 db to store download status")
     cmdl_parser.add_argument("url", action="store", nargs="*", help="fanclub or post URL")
 
     dl_group = cmdl_parser.add_argument_group("download options")
@@ -76,7 +77,7 @@ if __name__ == "__main__":
     #         password = getpass.getpass("Password: ")
 
     try:
-        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, exclude_file=cmdl_opts.exclude_file)
+        downloader = models.FantiaDownloader(session_arg=session_arg, dump_metadata=cmdl_opts.dump_metadata, parse_for_external_links=cmdl_opts.parse_for_external_links, download_thumb=cmdl_opts.download_thumb, directory=cmdl_opts.output_path, quiet=cmdl_opts.quiet, continue_on_error=cmdl_opts.continue_on_error, use_server_filenames=cmdl_opts.use_server_filenames, mark_incomplete_posts=cmdl_opts.mark_incomplete_posts, month_limit=cmdl_opts.month_limit, exclude_file=cmdl_opts.exclude_file, db_path=cmdl_opts.db_path)
         if cmdl_opts.download_fanclubs:
             try:
                 downloader.download_followed_fanclubs(limit=cmdl_opts.limit)

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     cmdl_parser.add_argument("-n", "--netrc", action="store_true", dest="netrc", help=argparse.SUPPRESS)
     cmdl_parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="suppress output")
     cmdl_parser.add_argument("-v", "--version", action="version", version=cmdl_version)
-    cmdl_parser.add_argument("--db", dest="db_path", help="sqlite3 db to store download status")
+    cmdl_parser.add_argument("--db", dest="db_path", help="database to track post download state")
     cmdl_parser.add_argument("url", action="store", nargs="*", help="fanclub or post URL")
 
     dl_group = cmdl_parser.add_argument_group("download options")

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -30,7 +30,7 @@ if __name__ == "__main__":
     cmdl_parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="suppress output")
     cmdl_parser.add_argument("-v", "--version", action="version", version=cmdl_version)
     cmdl_parser.add_argument("--db", dest="db_path", help="database to track post download state")
-    cmdl_parser.add_argument("--db-bypass-post-check", action="store_true", dest="db_bypass_post_check", help="bypass the metadata fetch if post is marked as complete in the database")
+    cmdl_parser.add_argument("--db-bypass-post-check", action="store_true", dest="db_bypass_post_check", help="bypass checking a post for new content if it's marked as completed on the database")
     cmdl_parser.add_argument("url", action="store", nargs="*", help="fanclub or post URL")
 
     dl_group = cmdl_parser.add_argument_group("download options")

--- a/fantiadl.py
+++ b/fantiadl.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     cmdl_parser.add_argument("-n", "--netrc", action="store_true", dest="netrc", help=argparse.SUPPRESS)
     cmdl_parser.add_argument("-q", "--quiet", action="store_true", dest="quiet", help="suppress output")
     cmdl_parser.add_argument("-v", "--version", action="version", version=cmdl_version)
-    cmdl_parser.add_argument("--db", dest="db_path", help="database to track post download state")
+    cmdl_parser.add_argument("--db", dest="db_path", help="database to track post download state (creates tables when first specified)")
     cmdl_parser.add_argument("--db-bypass-post-check", action="store_true", dest="db_bypass_post_check", help="bypass checking a post for new content if it's marked as completed on the database")
     cmdl_parser.add_argument("url", action="store", nargs="*", help="fanclub or post URL")
 

--- a/models.py
+++ b/models.py
@@ -379,6 +379,16 @@ class FantiaDownloader:
             return
         request.raise_for_status()
 
+        # Handle redirection
+        if request.url != url:
+            url_path = unquote(request.url.split("?", 1)[0])
+            server_filename = os.path.basename(url_path)
+            if server_filename in self.exclusions:
+                self.output("Server filename in exclusion list (skipping): {}\n".format(server_filename))
+                return
+            if use_server_filename:
+                filepath = os.path.join(os.path.dirname(filepath), server_filename)
+
         file_size = int(request.headers["Content-Length"])
         if os.path.isfile(filepath) and os.stat(filepath).st_size == file_size:
             self.output("File found (skipping): {}\n".format(filepath))

--- a/models.py
+++ b/models.py
@@ -19,7 +19,7 @@ import sys
 import time
 import traceback
 
-
+from db import FantiaDatabase
 import fantiadl
 
 FANTIA_URL_RE = re.compile(r"(?:https?://(?:(?:www\.)?(?:fantia\.jp/(fanclubs|posts)/)))([0-9]+)")
@@ -66,7 +66,7 @@ class FantiaClub:
 
 
 class FantiaDownloader:
-    def __init__(self, session_arg, chunk_size=1024 * 1024 * 5, dump_metadata=False, parse_for_external_links=False, download_thumb=False, directory=None, quiet=True, continue_on_error=False, use_server_filenames=False, mark_incomplete_posts=False, month_limit=None, exclude_file=None):
+    def __init__(self, session_arg, chunk_size=1024 * 1024 * 5, dump_metadata=False, parse_for_external_links=False, download_thumb=False, directory=None, quiet=True, continue_on_error=False, use_server_filenames=False, mark_incomplete_posts=False, month_limit=None, exclude_file=None, db_path=None):
         # self.email = email
         # self.password = password
         self.session_arg = session_arg
@@ -82,6 +82,8 @@ class FantiaDownloader:
         self.month_limit = dt.strptime(month_limit, "%Y-%m") if month_limit else None
         self.exclude_file = exclude_file
         self.exclusions = []
+        self.db = FantiaDatabase(db_path)
+
         self.initialize_session()
         self.login()
         self.create_exclusions()

--- a/models.py
+++ b/models.py
@@ -536,6 +536,7 @@ class FantiaDownloader:
             if db_post["converted_at"] != post_converted_at:
                 self.output("Post date does not match date in database. Checking for new contents...\n")
                 self.db.update_post_download_complete(post_id, download_complete=0)
+                self.db.update_post_converted_at(post_id, post_converted_at)
             else:
                 self.output("Post appears to have been downloaded completely. Skipping...\n".format(post_id))
                 return

--- a/models.py
+++ b/models.py
@@ -353,7 +353,7 @@ class FantiaDownloader:
             else:
                 page_number += 1
 
-    def perform_download(self, url, filepath, use_server_filename=False, use_db=False):
+    def perform_download(self, url, filepath, use_server_filename=False):
         """Perform a download for the specified URL while showing progress."""
         url_path = unquote(url.split("?", 1)[0])
         server_filename = os.path.basename(url_path)
@@ -369,6 +369,8 @@ class FantiaDownloader:
             self.output("Filename in exclusion list (skipping): {}\n".format(filename))
             return
 
+        # Currently, we only cache fantia S3 URLs
+        use_db = url_path.startswith("https://cc.fantia.jp/")
         if use_db and self.db.is_url_downloaded(url_path):
             self.output("URL already downloaded. Skipping...\n")
             return
@@ -433,8 +435,7 @@ class FantiaDownloader:
                 gallery_directory,
                 str(photo_counter) + "." + photo_url.split("?", 1)[0].rsplit(".", 1)[1]
             ) if gallery_directory else str(),
-            use_server_filename=self.use_server_filenames,
-            use_db=True
+            use_server_filename=self.use_server_filenames
         )
 
     def download_file(self, download_url, filename, post_directory):

--- a/models.py
+++ b/models.py
@@ -271,7 +271,6 @@ class FantiaDownloader:
             response.raise_for_status()
             response_page = BeautifulSoup(response.text, "html.parser")
             fanclub_links = response_page.select("div.mb-5-children > div:nth-of-type(1) a[href^=\"/fanclubs\"]")
-            print(response.text)
 
             for fanclub_link in fanclub_links:
                 fanclub_id = fanclub_link["href"].lstrip("/fanclubs/")

--- a/models.py
+++ b/models.py
@@ -515,9 +515,10 @@ class FantiaDownloader:
         post_title = post_json["title"]
         post_contents = post_json["post_contents"]
 
-        post_converted_at = int(dt.fromisoformat(post_json["converted_at"]).timestamp())
+        post_posted_at = int(parsedate_to_datetime(post_json["posted_at"]).timestamp())
+        post_converted_at = int(dt.fromisoformat(post_json["converted_at"]).timestamp()) if post_json["converted_at"] else post_posted_at
         if not db_post or db_post["converted_at"] != post_converted_at:
-            self.db.insert_post(post_id, post_title, post_json["fanclub"]["id"], int(parsedate_to_datetime(post_json["posted_at"]).timestamp()), post_converted_at)
+            self.db.insert_post(post_id, post_title, post_json["fanclub"]["id"], post_posted_at, post_converted_at)
 
         post_directory_title = sanitize_for_path(str(post_id))
 


### PR DESCRIPTION
### Background
pixivFANBOX killed many posts recently, several creators I'm supporting moved to fantia, and there's an urgent need to implement new full-automation download & organization.
Currently, fantiadl won't store the download state for each post. It sends a request for each post and each content file (even for files that already exist), which slows the download process by a lot and is not suitable for periodic cronjobs.

### Solution?
This PR implements a sqlite3 database to hold the download state for fantia post and post_content entries. It also holds the state of each URL downloaded (currently for images only, since fantia uses S3 to store images and uses UUID as the image name, I assume it's safe to do so).
Post contents and URLs that are present in the database will be skipped to speed up download & reduce requests sent. Posts will be marked as "complete" when all of its contents are accessible and downloaded to further reduce unnecessary requests.
It also fixed tiny mistakes in the `perform_download` method and change `incomplete_filename` to full filename with the `.tmp` suffix, which is ignored by most sync drives by default.
BTW, the database functionality is completely optional. It will be enabled only when you provide a path with the `--db` parameter.

### Request for comment
I'm currently storing the metadata required for my automated organization solution only. Since the table structure should be relatively hard to upgrade, please comment if you consider the DB structure needs change before this PR get merged. 